### PR TITLE
feat(TerraformConfig): add wfStepTemplateRevisionId field

### DIFF
--- a/types.go
+++ b/types.go
@@ -6992,6 +6992,9 @@ type TerraformConfig struct {
 	RunPreInitHooksOnDrift  *bool           `json:"runPreInitHooksOnDrift,omitempty" url:"runPreInitHooksOnDrift,omitempty"`
 	RunPrePlanHooksOnDrift  *bool           `json:"runPrePlanHooksOnDrift,omitempty" url:"runPrePlanHooksOnDrift,omitempty"`
 	RunPostPlanHooksOnDrift *bool           `json:"runPostPlanHooksOnDrift,omitempty" url:"runPostPlanHooksOnDrift,omitempty"`
+	// Fully-qualified workflow step template revision id pinned for this terraform config
+	// (e.g. "/<org>/<name>:<rev>").
+	WfStepTemplateRevisionId *string `json:"wfStepTemplateRevisionId,omitempty" url:"wfStepTemplateRevisionId,omitempty"`
 
 	extraProperties map[string]interface{}
 	rawJSON         json.RawMessage
@@ -7142,6 +7145,13 @@ func (t *TerraformConfig) GetRunPostPlanHooksOnDrift() *bool {
 		return nil
 	}
 	return t.RunPostPlanHooksOnDrift
+}
+
+func (t *TerraformConfig) GetWfStepTemplateRevisionId() *string {
+	if t == nil {
+		return nil
+	}
+	return t.WfStepTemplateRevisionId
 }
 
 func (t *TerraformConfig) GetExtraProperties() map[string]interface{} {


### PR DESCRIPTION
The workflow API returns and accepts TerraformConfig.wfStepTemplateRevisionId (a fully-qualified workflow step template revision id, e.g. "/<org>/<name>:<rev>") on V3 workflows, but the SDK's TerraformConfig struct did not model it, so it was silently dropped on read and unsettable on write. Add the *string field (omitempty) and its getter, matching the other optional TerraformConfig fields.