### PR TITLE
fix(IacInputData): make Data a pointer so an explicit empty object can be sent

### DIFF
--- a/types.go
+++ b/types.go
@@ -4482,7 +4482,12 @@ func (g *GeneratedWorkflowsListAllMsg) String() string {
 type IacInputData struct {
 	SchemaId   *string                     `json:"schemaId,omitempty" url:"schemaId,omitempty"`
 	SchemaType *IacInputDataSchemaTypeEnum `json:"schemaType,omitempty" url:"schemaType,omitempty"`
-	Data       map[string]interface{}      `json:"data,omitempty" url:"data"`
+	// Data is a pointer so an EXPLICIT empty object can be sent: a nil pointer omits the
+	// key entirely, while a pointer to an empty map serializes as "data": {}. With a plain
+	// map, json omitempty silently dropped an empty map from the payload, making it
+	// impossible to clear a template's default input data (the API requires the data key
+	// whenever iacInputData is present).
+	Data *map[string]interface{} `json:"data,omitempty" url:"data"`
 }
 
 // * `FORM_JSONSCHEMA` - FORM_JSONSCHEMA


### PR DESCRIPTION
## Problem

With `Data map[string]interface{} \`json:"data,omitempty"\``, Go's JSON marshaling silently drops an **empty** map from the payload. That makes it impossible to send `"data": {}` — which a Terraform provider user needs to **clear** a template's default input data instead of inheriting it.

The API's VCSConfig serializer (`commons.py`: `data = serializers.DictField(allow_null=False, required=True)`) requires the `data` key whenever `iacInputData` is present, and **accepts** `{}`. But since omitempty dropped the key, callers setting an empty map got:

```
VCSConfig.iacInputData.data: This field is required
```

Found via terraform-provider test WFT-CLEAR-002 (clear inherited iac_input_data with an explicit empty value).

## Fix

`Data *map[string]interface{}`:
- `nil` pointer → key omitted → inherit case unchanged
- pointer to empty map → `"data": {}` → explicit clear now possible
- pointer to populated map → unchanged behavior

Verified marshal/unmarshal in both directions:
```
nil pointer:          {}
ptr to empty map:     {"data":{}}
ptr to populated map: {"data":{"k":"v"}}
unmarshal absent  -> nil
unmarshal populated -> filled map
```

## Breaking change note

Consumers reading `.Data` must nil-check and deref (`*x.Data`). No SDK-internal usages exist. The terraform provider adaptation is ready to follow this release.

SDK unit tests: the pre-existing env-dependent failures (workflows/stacktemplates suites) are identical on main — no new failures from this change.